### PR TITLE
Push secrets cirun

### DIFF
--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install 1Password CLI
-        uses: 1password/install-cli-action@v1
+        uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f # v1.0.0
 
       - name: Load GH token
         id: op-gh-token
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0
         with:
           export-env: false
         env:
@@ -37,7 +37,7 @@ jobs:
       #     organization: conda-forge
       #     requested-token-type: urn:pulumi:token-type:access_token:organization
 
-      - uses: pulumi/actions@v6
+      - uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6.0.0
         with:
           command: up
           refresh: true

--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -1,0 +1,45 @@
+name: "Push secrets from 1Password to Github Actions"
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - "push-secrets-*"
+
+jobs:
+  push-secrets:
+    name: "Push Secret"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v1
+
+      - name: Load GH token
+        id: op-gh-token
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GITHUB_TOKEN: op://pulumi/gh-pulumi-runner-token/credential
+
+      # - uses: pulumi/auth-actions@v1
+      #   with:
+      #     organization: conda-forge
+      #     requested-token-type: urn:pulumi:token-type:access_token:organization
+
+      - uses: pulumi/actions@v6
+        with:
+          command: up
+          refresh: true
+          stack-name: cf-demos/sync-secrets/secrets
+          work-dir: "./sync-secrets"
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.op-gh-token.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - "push-secrets-*"
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   push-secrets:
     name: "Push Secret"

--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -14,7 +14,7 @@ jobs:
     name: "Push Secret"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@v1

--- a/README.md
+++ b/README.md
@@ -6,3 +6,30 @@ conda-forge infrastructure.
 > [!NOTE]
 > This is not a forum for end-user questions
 
+## Sync-secrets
+
+The `sync-secrets` pulumi project syncs secrets from the conda-forge 1password vault to relevant services (eg. to GitHub).
+
+### Running locally
+
+* Install the 1password cli
+* Export environment variables:
+  * `GITHUB_TOKEN` (permissions to `repo` and `admin:org`)
+  * `OP_SERVICE_ACCOUNT_TOKEN` (token for 1password service account)
+*  Setup pulumi (only needs to be run once)
+```
+$ pulumi install
+$ pulumi plugin install resource onepassword --server github://api.github.com/1Password/pulumi-onepassword
+```
+* Apply changes
+```
+$ pulumi up
+```
+
+### Try it out with GHA
+
+[`.github/workflows/push-1password-secrets-to-gha`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-gha.yaml)
+
+Try it out by:
+* create and push a branch names with following the pattern "push-secrets-*"
+* observe the run in github action that populates secrets

--- a/sync-secrets/Pulumi.yaml
+++ b/sync-secrets/Pulumi.yaml
@@ -1,0 +1,38 @@
+name: sync-secrets
+description: sync secrets from 1Password to GH
+runtime: yaml
+config:
+  'pulumi:tags': {value: {'pulumi:template': yaml}}
+  github:owner:
+        value: conda-forge
+variables:
+  cirun-api-key:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cirun-api-key
+        vault: pulumi
+  repo-admin-requests:
+    fn::invoke:
+      function: github:getRepository
+      arguments:
+        fullName: conda-forge/admin-requests
+resources:
+  onepassword-provider:
+    type: pulumi:providers:onepassword
+    options:
+      version: 1.1.4
+      pluginDownloadURL: github://api.github.com/1Password/
+  gh-org-secret-cirun-api-key:
+    type: github:ActionsOrganizationSecret
+    options:
+      protect: false
+      retainOnDelete: true
+      deleteBeforeReplace: true
+    properties:
+      secretName: CIRUN_API_KEY
+      plaintextValue: ${cirun-api-key.credential}
+      visibility: selected
+      selectedRepositoryIds:
+        - ${repo-admin-requests.repoId}
+outputs: {}

--- a/sync-secrets/Pulumi.yaml
+++ b/sync-secrets/Pulumi.yaml
@@ -28,7 +28,7 @@ resources:
     options:
       protect: false
       retainOnDelete: true
-      deleteBeforeReplace: true
+      deleteBeforeReplace: false
     properties:
       secretName: CIRUN_API_KEY
       plaintextValue: ${cirun-api-key.credential}


### PR DESCRIPTION
Add workflow for pushing secrets from 1password to GH for `CIRUN_API_KEY`. `CIRUN_API_KEY` is a conda-forge org level secret and only `conda-forge/admin-requests` should have access to it.