### PR TITLE
Configure openid for github

### DIFF
--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -32,10 +32,10 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           GITHUB_TOKEN: op://pulumi/gh-pulumi-runner-token/credential
 
-      # - uses: pulumi/auth-actions@v1
-      #   with:
-      #     organization: conda-forge
-      #     requested-token-type: urn:pulumi:token-type:access_token:organization
+      - uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
+        with:
+          organization: conda-forge
+          requested-token-type: urn:pulumi:token-type:access_token:organization
 
       - uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6.0.0
         with:
@@ -44,6 +44,5 @@ jobs:
           stack-name: conda-forge/sync-secrets/secrets
           work-dir: "./sync-secrets"
         env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.op-gh-token.outputs.GITHUB_TOKEN }}


### PR DESCRIPTION
The pulumi conda-forge org has been configured with a OIDC configuration policy for github. This PR:
* updates ci to take advantage of that by using the pulumi auth-action
* removes usage of the `PULUMI_ACCESS_TOKEN` secret

docs: https://www.pulumi.com/docs/pulumi-cloud/access-management/oidc/client/github/