### PR TITLE
Use conda-forge-bot user to auth pulumi

### DIFF
--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -35,7 +35,8 @@ jobs:
       - uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
         with:
           organization: conda-forge
-          requested-token-type: urn:pulumi:token-type:access_token:organization
+          requested-token-type: urn:pulumi:token-type:access_token:personal
+          scope: user:conda-forge-bot
 
       - uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6.0.0
         with:


### PR DESCRIPTION
Now that conda forge has the OSS tier from pulumi (https://www.pulumi.com/pricing/open-source-free-tier/) we do not have support to request auth tokens for the organization (this is an enterprise feature). So, I've setup a `conda-forge-bot` user (login details in 1password) that can be used to run workloads. 

Note in order to make this work, I also updates the OIDC `github` policy in the conda-forge pulumi org to allow personal tokens for the user `conda-forge-bot`. 

Without this change, we get the error ([workflow link](https://github.com/conda-forge/infrastructure/actions/runs/12206189026/job/34055144573#step:5:7)):
> Error: Invalid response from token exchange 401: Unauthorized (access_denied: policy authorization error: Org tokens are not supported for non enterprise organizations)

