### PR TITLE
Push secrets to heroku

### DIFF
--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -43,8 +43,8 @@ jobs:
         with:
           command: up
           refresh: true
-          stack-name: conda-forge/sync-secrets/secrets
-          work-dir: "./sync-secrets"
+          stack-name: conda-forge/sync-secrets-gha/secrets
+          work-dir: "./sync-secrets-gha"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           GITHUB_TOKEN: ${{ steps.op-gh-token.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  push-secrets:
-    name: "Push Secret"
+  push-github-secrets:
+    name: "Push Github Secret"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/push-1password-secrets-to-heroku.yaml
+++ b/.github/workflows/push-1password-secrets-to-heroku.yaml
@@ -1,4 +1,4 @@
-name: "Push secrets from 1Password to Github Actions"
+name: "Push secrets from 1Password to Heroku"
 
 permissions:
   id-token: write
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  push-github-secrets:
-    name: "Push Github Secret"
+  push-heroku-secrets:
+    name: "Push Heroku Secret"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -24,14 +24,14 @@ jobs:
       - name: Install 1Password CLI
         uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f # v1.0.0
 
-      - name: Load GH token
-        id: op-gh-token
+      - name: Load Heroku token
+        id: op-heroku-token
         uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0
         with:
           export-env: false
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_TOKEN: op://pulumi/gh-pulumi-runner-token/credential
+          HEROKU_API_KEY: op://pulumi/heroku-pulumi-runner-token/credential
 
       - uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
         with:
@@ -43,8 +43,8 @@ jobs:
         with:
           command: up
           refresh: true
-          stack-name: conda-forge/sync-secrets/secrets
-          work-dir: "./sync-secrets"
+          stack-name: conda-forge/sync-secrets-heroku/secrets
+          work-dir: "./sync-secrets-heroku"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          GITHUB_TOKEN: ${{ steps.op-gh-token.outputs.GITHUB_TOKEN }}
+          HEROKU_API_KEY: ${{ steps.op-heroku-token.outputs.HEROKU_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ conda-forge infrastructure.
 
 ## Sync-secrets
 
-The `sync-secrets` pulumi project syncs secrets from the conda-forge 1password vault to relevant services (eg. to GitHub).
+The `sync-secrets` pulumi project syncs secrets from the conda-forge 1password vault to Github
 
 ### Running locally
 
@@ -34,6 +34,25 @@ Try it out by:
 * create and push a branch names with following the pattern "push-secrets-*"
 * observe the run in github action that populates secrets
 
+## Sync-secrets-heroku
+
+The `sync-secrets-heroku` pulumi project syncs secrets from the conda-forge 1password vault to relevant services (eg. to GitHub).
+
+### Running locally
+
+* Install the 1password cli
+* Export environment variables:
+  * `HEROKU_API_KEY` (api token for heroku)
+  * `OP_SERVICE_ACCOUNT_TOKEN` (token for 1password service account)
+*  Setup pulumi (only needs to be run once)
+```
+$ pulumi install
+$ pulumi plugin install resource onepassword --server github://api.github.com/1Password/pulumi-onepassword
+```
+* Apply changes
+```
+$ pulumi up
+```
 
 ### Sponsored by Pulumi
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ $ pulumi up
 [`.github/workflows/push-1password-secrets-to-gha`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-gha.yaml)
 
 Try it out by:
-* create and push a branch names with following the pattern "push-secrets-*"
+* create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
 * observe the run in github action that populates secrets
 
 ## Sync-secrets-heroku
 
-The `sync-secrets-heroku` pulumi project syncs secrets from the conda-forge 1password vault to relevant services (eg. to GitHub).
+The `sync-secrets-heroku` pulumi project syncs secrets from the conda-forge 1password vault to Heroku
 
 ### Running locally
 
@@ -53,6 +53,14 @@ $ pulumi plugin install resource onepassword --server github://api.github.com/1P
 ```
 $ pulumi up
 ```
+
+### Try it out with GHA
+
+[`.github/workflows/push-1password-secrets-to-gha`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-gha.yaml)
+
+Try it out by:
+* create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
+* observe the run in github action that populates secrets
 
 ### Sponsored by Pulumi
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ conda-forge infrastructure.
 > [!NOTE]
 > This is not a forum for end-user questions
 
-## Sync-secrets
+## Sync-secrets-gha
 
-The `sync-secrets` pulumi project syncs secrets from the conda-forge 1password vault to Github
+The `sync-secrets-gha` pulumi project syncs secrets from the conda-forge 1password vault to Github
 
 ### Running locally
 

--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -6,6 +6,7 @@ config:
   github:owner:
         value: conda-forge
 variables:
+  # get 1password secrets
   azure-token:
     fn::invoke:
       function: onepassword:getItem
@@ -96,7 +97,7 @@ variables:
       arguments:
         title: staging-binstar-token
         vault: pulumi
-
+  # get GH repos
   repo-admin-migrations:
     fn::invoke:
       function: github:getRepository

--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: sync-secrets
+name: sync-secrets-gha
 description: sync secrets from 1Password to GH
 runtime: yaml
 config:

--- a/sync-secrets-heroku/Pulumi.yaml
+++ b/sync-secrets-heroku/Pulumi.yaml
@@ -1,0 +1,75 @@
+name: sync-secrets-heroku
+description: sync secrets from 1Password to Heroku
+runtime: yaml
+config:
+  'pulumi:tags': {value: {'pulumi:template': yaml}}
+  github:owner:
+        value: conda-forge
+variables:
+  autotick-bot-gh-token:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: autotick-bot-gh-token 
+        vault: pulumi
+  cf-admin-github-token: # GH_TOKEN
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cf-admin-github-token
+        vault: pulumi
+  cf-webservices-feedstock-private-key:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cf-webservices-feedstock-private-key
+        vault: pulumi
+  cf-webservices-token:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cf-webservices-token
+        vault: pulumi
+  cf-webservices-private-key:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cf-webservices-private-key
+        vault: pulumi
+  heroku-only-staging-binstar-token:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: heroku-only-staging-binstar-token
+        vault: pulumi
+  prod-binstar-token:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: prod-binstar-token
+        vault: pulumi
+
+  heroku-app:
+    fn::invoke:
+      function: heroku:app/getApp:getApp
+      arguments:
+        name: conda-forge
+resources:
+  onepassword-provider:
+    type: pulumi:providers:onepassword
+    options:
+      version: 1.1.4
+      pluginDownloadURL: github://api.github.com/1Password/
+  heroku-app-config:
+    type: heroku:app:ConfigAssociation
+    properties:
+        appId: ${heroku-app.id}
+        sensitiveVars:
+            AUTOTICK_BOT_GH_TOKEN: ${autotick-bot-gh-token.credential}
+            CF_WEBSERVICES_FEEDSTOCK_PRIVATE_KEY: ${cf-webservices-feedstock-private-key.credential}
+            CF_WEBSERVICES_PRIVATE_KEY: ${cf-webservices-private-key.credential}
+            CF_WEBSERVICES_TOKEN: ${cf-webservices-token.credential}
+            GH_TOKEN: ${cf-admin-github-token.credential}
+            PROD_BINSTAR_TOKEN: ${prod-binstar-token.credential}
+            STAGING_BINSTAR_TOKEN: ${heroku-only-staging-binstar-token.credential}
+outputs: {}

--- a/sync-secrets-heroku/Pulumi.yaml
+++ b/sync-secrets-heroku/Pulumi.yaml
@@ -3,9 +3,10 @@ description: sync secrets from 1Password to Heroku
 runtime: yaml
 config:
   'pulumi:tags': {value: {'pulumi:template': yaml}}
-  github:owner:
+  'github:owner':
         value: conda-forge
 variables:
+  # get 1password secrets
   autotick-bot-gh-token:
     fn::invoke:
       function: onepassword:getItem
@@ -48,7 +49,7 @@ variables:
       arguments:
         title: prod-binstar-token
         vault: pulumi
-
+  # get target heroku app
   heroku-app:
     fn::invoke:
       function: heroku:app/getApp:getApp


### PR DESCRIPTION
This PR enables syncing secrets from 1password -> heroku (conda-forge app).

* introduces the use of the [heroku pulumi package](https://www.pulumi.com/registry/packages/heroku/)
* runs against the new pulumi stack sync-secrets-heroku (opposed to the gh stack sync-secrets)
* adds a GHA for syncing secrets to heroku 
  * can be run separately from the GHA for syncing GH secrets by using [GHA workflows](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
  * can be run at the same time as other syncing actions by pushing to a branch with prefix `push-secrets-*`
* renames the `sync-secrets` folder to `sync-secrets-gha` 