### PR TITLE
Azure push secrets

### DIFF
--- a/.github/workflows/push-1password-secrets-to-azure.yaml
+++ b/.github/workflows/push-1password-secrets-to-azure.yaml
@@ -1,0 +1,51 @@
+name: "Push secrets from 1Password to Azure"
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - "azure-push-secrets-*"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  push-azure-secrets:
+    name: "Push Azure Secret"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@143a85f84a90555d121cde2ff5872e393a47ab9f # v1.0.0
+
+      - name: Load Azure token
+        id: op-azure-token
+        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AZDO_PERSONAL_ACCESS_TOKEN: op://pulumi/azure-pulumi-runner/credential
+
+      - uses: pulumi/auth-actions@80dec0d5e009a11565cbf87d9ef9103fc7d24198 # v1.0.0
+        with:
+          organization: conda-forge
+          requested-token-type: urn:pulumi:token-type:access_token:personal
+          scope: user:conda-forge-bot
+
+      - uses: pulumi/actions@13b8b7177d6fb736766875dac9b78aab07bd785f # v6.0.1
+        with:
+          command: up
+          refresh: true
+          stack-name: conda-forge/sync-secrets-azure/secrets
+          work-dir: "./sync-secrets-azure"
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          AZDO_PERSONAL_ACCESS_TOKEN: ${{ steps.op-azure-token.outputs.AZDO_PERSONAL_ACCESS_TOKEN }}
+          AZDO_ORG_SERVICE_URL: https://dev.azure.com/conda-forge

--- a/.github/workflows/push-1password-secrets-to-gha.yaml
+++ b/.github/workflows/push-1password-secrets-to-gha.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - "push-secrets-*"
+      - "gha-push-secrets-*"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/push-1password-secrets-to-heroku.yaml
+++ b/.github/workflows/push-1password-secrets-to-heroku.yaml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - "push-secrets-*"
+      - "heroku-push-secrets-*"
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,35 @@ conda-forge infrastructure.
 > [!NOTE]
 > This is not a forum for end-user questions
 
+## Sync-secrets-azure
+
+The `sync-secrets-azure` pulumi project syncs secrets from the conda-forge 1password vault to Azure
+
+### Running locally
+
+* Install the 1password cli
+* Export environment variables:
+  * `AZDO_PERSONAL_ACCESS_TOKEN` (api token for AZURE)
+  * `AZDO_ORG_SERVICE_URL` (org service url for AZURE)
+  * `OP_SERVICE_ACCOUNT_TOKEN` (token for 1password service account)
+*  Setup pulumi (only needs to be run once)
+```
+$ pulumi install
+$ pulumi plugin install resource onepassword --server github://api.github.com/1Password/pulumi-onepassword
+```
+* Apply changes
+```
+$ pulumi up
+```
+
+### Try it out with GHA
+
+[`.github/workflows/push-1password-secrets-to-azure`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-azure.yaml)
+
+Try it out by:
+* create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
+* observe the run in github action that populates secrets
+
 ## Sync-secrets-gha
 
 The `sync-secrets-gha` pulumi project syncs secrets from the conda-forge 1password vault to Github
@@ -56,7 +85,7 @@ $ pulumi up
 
 ### Try it out with GHA
 
-[`.github/workflows/push-1password-secrets-to-gha`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-gha.yaml)
+[`.github/workflows/push-1password-secrets-to-heroku`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-heroku.yaml)
 
 Try it out by:
 * create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ pulumi up
 [`.github/workflows/push-1password-secrets-to-azure`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-azure.yaml)
 
 Try it out by:
-* create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
+* create and push a branch name following the pattern "azure-push-secrets-*" OR [manually run](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) the [1Password-to-Azure workflow](https://github.com/conda-forge/infrastructure/actions/workflows/push-1password-secrets-to-azure.yaml)
 * observe the run in github action that populates secrets
 
 ## Sync-secrets-gha
@@ -88,7 +88,7 @@ $ pulumi up
 [`.github/workflows/push-1password-secrets-to-heroku`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-heroku.yaml)
 
 Try it out by:
-* create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
+* create and push a branch named with the pattern "heroku-push-secrets-*" OR [manually run](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) the [1Password-to-Heroku workflow](https://github.com/conda-forge/infrastructure/actions/workflows/push-1password-secrets-to-heroku.yaml)
 * observe the run in github action that populates secrets
 
 ### Sponsored by Pulumi

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ $ pulumi up
 
 [`.github/workflows/push-1password-secrets-to-gha`](https://github.com/conda-forge/infrastructure/blob/main/.github/workflows/push-1password-secrets-to-gha.yaml)
 
+
 Try it out by:
-* create and push a branch names with following the pattern "push-secrets-*" OR [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
+* create and push a branch name following the pattern "gha-push-secrets-*" OR [manually run](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow) the [1Password-to-GHA workflow](https://github.com/conda-forge/infrastructure/actions/workflows/push-1password-secrets-to-gha.yaml)
 * observe the run in github action that populates secrets
 
 ## Sync-secrets-heroku

--- a/sync-secrets-azure/Pulumi.yaml
+++ b/sync-secrets-azure/Pulumi.yaml
@@ -1,0 +1,50 @@
+name: sync-secrets-azure
+description: sync secrets from 1Password to azure
+runtime: yaml
+config:
+  'pulumi:tags': {value: {'pulumi:template': yaml}}
+  'github:owner':
+        value: conda-forge
+variables:
+  # get 1password secrets
+  prod-binstar-token:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: prod-binstar-token
+        vault: pulumi
+  staging-binstar-token:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: staging-binstar-token
+        vault: pulumi
+  # get project id
+  azure-feedstock-project-id:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: azure-feedstock-project-id
+        vault: pulumi
+resources:
+  onepassword-provider:
+    type: pulumi:providers:onepassword
+    options:
+      version: 1.1.4
+      pluginDownloadURL: github://api.github.com/1Password/
+  anacondaOrgVariableGroup:
+    type: azuredevops:VariableGroup
+    name: anaconda-org
+    properties:
+      projectId: ${azure-feedstock-project-id.credential}
+      name: anaconda-org
+      description: anaconda-org secrets (provisioned from https://github.com/conda-forge/infrastructure)
+      allowAccess: true
+      variables:
+        - name: BINSTAR_TOKEN
+          secretValue: ${prod-binstar-token.credential}
+          isSecret: true
+        - name: STAGING_BINSTAR_TOKEN
+          secretValue: ${staging-binstar-token.credential}
+          isSecret: true
+outputs: {}


### PR DESCRIPTION
This PR enables syncing secrets from 1password -> azure (feedstock project).

* runs against the new pulumi stack sync-secrets-azure 
* updates the workflows to not all run on branches starting with `push-secrets-*`