### PR TITLE
fix: manage docker tokens via pulumi

### DIFF
--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -363,7 +363,7 @@ resources:
       secretName: ${gh-org-cf-bot-dh-password.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-docker-images.repoID}
+        - ${repo-docker-images.repoId}
         - ${repo-conda-forge-feedstock-ops.repoId}
 
   # Secret: CF_CURATOR_APP_ID
@@ -443,7 +443,7 @@ resources:
       secretName: ${gh-org-secret-cf-daemon-quay-password.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-docker-images.repoID}
+        - ${repo-docker-images.repoId}
 
   # Secret: CF_DAEMON_QUAY_API_KEY
   gh-org-secret-cf-daemon-quay-api-key:
@@ -466,7 +466,7 @@ resources:
       secretName: ${gh-org-secret-cf-daemon-quay-api-key.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-docker-images.repoID}
+        - ${repo-docker-images.repoId}
 
   # Secret: CF_DAEMON_TRAVIS_TOKEN
   gh-org-secret-cf-daemon-travis-token:

--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -37,6 +37,18 @@ variables:
       arguments:
         title: cf-curator-private-key
         vault: pulumi
+  cf-daemon-quay-password:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cf-daemon-quay-password
+        vault: pulumi
+  cf-daemon-quay-api-key:
+    fn::invoke:
+      function: onepassword:getItem
+      arguments:
+        title: cf-daemon-quay-api-key
+        vault: pulumi
   cf-daemon-travis-token:
     fn::invoke:
       function: onepassword:getItem
@@ -241,6 +253,11 @@ variables:
       function: github:getRepository
       arguments:
         fullName: conda-forge/conda-forge-webservices
+  repo-docker-images:
+    fn::invoke:
+      function: github:getRepository
+      arguments:
+        fullName: conda-forge/docker-images
   repo-infrastructure:
     fn::invoke:
       function: github:getRepository
@@ -346,8 +363,7 @@ resources:
       secretName: ${gh-org-cf-bot-dh-password.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-webservices-dispatch-action.repoId}
-        - ${repo-automerge-action.repoId}
+        - ${repo-repo-docker-images.repoID}
         - ${repo-conda-forge-feedstock-ops.repoId}
 
   # Secret: CF_CURATOR_APP_ID
@@ -405,6 +421,52 @@ resources:
         - ${repo-core-notes.repoId}
         - ${repo-conda-forge-webservices.repoId}
         - ${repo-webservices-dispatch-action.repoId}
+
+  # Secret: CF_DAEMON_QUAY_PASSWORD
+  gh-org-secret-cf-daemon-quay-password:
+    type: github:ActionsOrganizationSecret
+    options:
+      protect: false
+      retainOnDelete: true
+      deleteBeforeReplace: false
+    properties:
+      secretName: CF_DAEMON_QUAY_PASSWORD
+      value: ${cf-daemon-quay-password.credential}
+      visibility: selected
+  gh-org-secret-cf-daemon-quay-password-repos:
+    type: github:ActionsOrganizationSecretRepositories
+    options:
+      protect: false
+      retainOnDelete: true
+      deleteBeforeReplace: false
+    properties:
+      secretName: ${gh-org-secret-cf-daemon-quay-password.secretName}
+      selectedRepositoryIds:
+        - ${repo-conda-forge-webservices.repoId}
+        - ${repo-repo-docker-images.repoID}
+
+  # Secret: CF_DAEMON_QUAY_API_KEY
+  gh-org-secret-cf-daemon-quay-api-key:
+    type: github:ActionsOrganizationSecret
+    options:
+      protect: false
+      retainOnDelete: true
+      deleteBeforeReplace: false
+    properties:
+      secretName: CF_DAEMON_QUAY_API_KEY
+      value: ${cf-daemon-quay-api-key.credential}
+      visibility: selected
+  gh-org-secret-cf-daemon-quay-api-key-repos:
+    type: github:ActionsOrganizationSecretRepositories
+    options:
+      protect: false
+      retainOnDelete: true
+      deleteBeforeReplace: false
+    properties:
+      secretName: ${gh-org-secret-cf-daemon-quay-api-key.secretName}
+      selectedRepositoryIds:
+        - ${repo-conda-forge-webservices.repoId}
+        - ${repo-repo-docker-images.repoID}
 
   # Secret: CF_DAEMON_TRAVIS_TOKEN
   gh-org-secret-cf-daemon-travis-token:

--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -363,7 +363,7 @@ resources:
       secretName: ${gh-org-cf-bot-dh-password.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-repo-docker-images.repoID}
+        - ${repo-docker-images.repoID}
         - ${repo-conda-forge-feedstock-ops.repoId}
 
   # Secret: CF_CURATOR_APP_ID
@@ -443,7 +443,7 @@ resources:
       secretName: ${gh-org-secret-cf-daemon-quay-password.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-repo-docker-images.repoID}
+        - ${repo-docker-images.repoID}
 
   # Secret: CF_DAEMON_QUAY_API_KEY
   gh-org-secret-cf-daemon-quay-api-key:
@@ -466,7 +466,7 @@ resources:
       secretName: ${gh-org-secret-cf-daemon-quay-api-key.secretName}
       selectedRepositoryIds:
         - ${repo-conda-forge-webservices.repoId}
-        - ${repo-repo-docker-images.repoID}
+        - ${repo-docker-images.repoID}
 
   # Secret: CF_DAEMON_TRAVIS_TOKEN
   gh-org-secret-cf-daemon-travis-token:


### PR DESCRIPTION
We apparently missed this in our initial move to pulumi. Fixing now. 

Need to merge the PRs below after this one:

- [ ] https://github.com/conda-forge/conda-forge-webservices/pull/1358
- [ ] https://github.com/conda-forge/docker-images/pull/331

