### PR TITLE
feat: add merge_group event to GitHub webhook for linting

### DIFF
--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -578,6 +578,7 @@ resources:
         url: https://conda-forge.herokuapp.com/conda-linting/org-hook
       events:
         - pull_request
+        - merge_group
 
   gh-org-webhook-conda-forge-feedstocks-org-hook:
     type: github:OrganizationWebhook


### PR DESCRIPTION
Part of https://github.com/conda-forge/staged-recipes/pull/32820 for enabling the merge queue on staged-recipes.