### PR TITLE
feat: add webhook secret to staged-recipes

### DIFF
--- a/sync-secrets-gha/Pulumi.yaml
+++ b/sync-secrets-gha/Pulumi.yaml
@@ -524,6 +524,7 @@ resources:
       selectedRepositoryIds:
         - ${repo-admin-migrations.repoId}
         - ${repo-conda-forge-webservices.repoId}
+        - ${repo-staged-recipes.repoId}
 
   # repo webhooks
   gh-repo-webhook-staged-recipes-labeler-hook:


### PR DESCRIPTION
This PR is to allow the staged-recipes linter to bump the webservices linter for the merge group.